### PR TITLE
Updated REGEX for prettier comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function applyReplacements(buffer, fileExt, commentStart, commentEnd, conditions
 }
 
 function escapeForRegExp(str) {
-    return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    return str.replace(/[-\/\\^$*+?.()|[\]{ }]/g, '\\$&');
 }
 
 function getRemovalTagsRegExp(commentStart, commentEnd, key) {


### PR DESCRIPTION
Add a small change to the REGEX statement to allow for a space between the comment identifier.  This fixes the problem with code formatters.

i.e.

```
//removeIf(production)
foo();
//endRemoveIf(production)
```

will often be reformatted to:

```
// removeIf(production)
foo();
// endRemoveIf(production)
```